### PR TITLE
FIX: all Document responses have the same schema, regardless of their type

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,2 +1,4 @@
 node_modules
 dist/
+
+.DS_Store

--- a/src/resources/Documents.ts
+++ b/src/resources/Documents.ts
@@ -1,10 +1,7 @@
 import { Pagination } from "./base/AboundResource";
 import { AboundBulkResponse, AboundResponse } from "./base/AboundResponse";
 import { AboundUserScopedResource } from "./base/AboundUserScopedResource";
-import {
-  AccountStatementDocument,
-  AccountStatementDocumentRequest,
-} from "./document-types/AccountStatement";
+import { AccountStatementDocumentRequest } from "./document-types/AccountStatement";
 
 export type DocumentRequest = AccountStatementDocumentRequest; // | ScheduleCDocumentRequest, etc.
 
@@ -17,11 +14,14 @@ export interface DocumentParameters extends Pagination {
   year?: string | number; // applies a filter based on year
 }
 
-export interface BaseDocumentResponse {
+export interface Document {
   documentId: Readonly<string | null>;
+  documentURL: Readonly<string | null>;
+  documentName: Readonly<string>;
+  type: Readonly<DocumentType>;
+  year: string;
+  createdTimestamp: Readonly<number>;
 }
-
-export type Document = AccountStatementDocument; // | ScheduleCDocument, etc.
 
 export enum DocumentType {
   ACCOUNT_STATEMENT = "accountStatement",

--- a/src/resources/Documents.ts
+++ b/src/resources/Documents.ts
@@ -19,7 +19,7 @@ export interface Document {
   documentURL: Readonly<string | null>;
   documentName: Readonly<string>;
   type: Readonly<DocumentType>;
-  year: string;
+  year: Readonly<string>;
   status?: Readonly<string>;
   message?: Readonly<string>;
   createdTimestamp: Readonly<number>;

--- a/src/resources/Documents.ts
+++ b/src/resources/Documents.ts
@@ -20,6 +20,8 @@ export interface Document {
   documentName: Readonly<string>;
   type: Readonly<DocumentType>;
   year: string;
+  status?: Readonly<string>;
+  message?: Readonly<string>;
   createdTimestamp: Readonly<number>;
 }
 

--- a/src/resources/document-types/AccountStatement.ts
+++ b/src/resources/document-types/AccountStatement.ts
@@ -1,8 +1,4 @@
-import {
-  BaseDocumentRequest,
-  BaseDocumentResponse,
-  DocumentType,
-} from "../Documents";
+import { BaseDocumentRequest, DocumentType } from "../Documents";
 
 // account statement request body
 export interface AccountStatementDocumentRequest extends BaseDocumentRequest {
@@ -40,13 +36,4 @@ export interface AccountStatementBankCustomerService {
   email: string;
   website: string;
   instructions?: string;
-}
-
-// account statement response body
-export interface AccountStatementDocument extends BaseDocumentResponse {
-  documentURL: Readonly<string | null>;
-  documentName: Readonly<string>;
-  type: Readonly<DocumentType>;
-  year: string;
-  createdTimestamp: Readonly<number>;
 }

--- a/tests/resources/AccountStatementDocuments.spec.ts
+++ b/tests/resources/AccountStatementDocuments.spec.ts
@@ -3,8 +3,7 @@ import {
   AboundBulkResponse,
   AboundResponse,
 } from "../../src/resources/base/AboundResponse";
-import { DocumentType } from "../../src/resources/Documents";
-import { AccountStatementDocument } from "../../src/resources/document-types/AccountStatement";
+import { Document, DocumentType } from "../../src/resources/Documents";
 import {
   createAboundClient,
   PUBLIC_BANK_LOGO_URL,
@@ -30,7 +29,7 @@ describe("Abound Account Statement Documents", () => {
       const accountNumber = randomNumberString(9);
       const last4 = accountNumber.slice(-4);
 
-      const createdDocuments: AboundBulkResponse<AccountStatementDocument> =
+      const createdDocuments: AboundBulkResponse<Document> =
         await abound.documents.create(TEST_USER_ID, [
           {
             type: DocumentType.ACCOUNT_STATEMENT,
@@ -79,7 +78,7 @@ describe("Abound Account Statement Documents", () => {
 
   describe("list", () => {
     it("returns a promise that resolves to an object that includes a list of the user's Documents on success", async () => {
-      const documents: AboundBulkResponse<AccountStatementDocument> =
+      const documents: AboundBulkResponse<Document> =
         await abound.documents.list(TEST_USER_ID);
 
       expect(bulkNormalizeNonIdempotentFields(documents.data))
@@ -98,7 +97,7 @@ describe("Abound Account Statement Documents", () => {
     });
 
     it("returns a promise that resolves to an object that includes a list of the user's Documents filtered by year on success when querying by year", async () => {
-      const filteredDocuments: AboundBulkResponse<AccountStatementDocument> =
+      const filteredDocuments: AboundBulkResponse<Document> =
         await abound.documents.list(TEST_USER_ID, {
           year: "2021",
         });
@@ -146,7 +145,7 @@ describe("Abound Account Statement Documents", () => {
   // TODO restore this test after the API properly returns a 200 response
   describe.skip("retrieve", () => {
     it("returns a promise that resolves to an object that includes a single Document on success", async () => {
-      const document: AboundResponse<AccountStatementDocument> =
+      const document: AboundResponse<Document> =
         await abound.documents.retrieve(TEST_USER_ID, TEST_DOCUMENT_ID);
 
       expect(document.data).toMatchInlineSnapshot();
@@ -154,15 +153,11 @@ describe("Abound Account Statement Documents", () => {
   });
 });
 
-function bulkNormalizeNonIdempotentFields(
-  documents: AccountStatementDocument[]
-) {
+function bulkNormalizeNonIdempotentFields(documents: Document[]) {
   return documents.map((d) => normalizeNonIdempotentFields(d));
 }
 
-function normalizeNonIdempotentFields(
-  document: AccountStatementDocument
-): AccountStatementDocument {
+function normalizeNonIdempotentFields(document: Document): Document {
   document.documentURL = removeQueryParameters(document.documentURL!);
   document.createdTimestamp = 1630000000000;
 

--- a/tests/resources/Documents.spec.ts
+++ b/tests/resources/Documents.spec.ts
@@ -17,7 +17,7 @@ import {
 
 const TEST_DOCUMENT_ID = "documentId_testefbd5d3d9ee9526ef9ff89a7c6b879174170";
 
-describe("Abound Account Statement Documents", () => {
+describe("Abound Documents", () => {
   let abound: Abound;
 
   beforeAll(() => {


### PR DESCRIPTION
On the first pass, I'd incorrectly assumed that different `Document` response bodies might have different schemas depending on their `type`. This holds true for different `Document` _request bodies_, but it seems like the responses are all normalized.