### PR TITLE
FEAT/FIX: remove 1099-INT as a possible income type, add income.documentType

### DIFF
--- a/README.md
+++ b/README.md
@@ -310,7 +310,7 @@ console.log(response.data.status);
 Create `Income`s:
 
 ```ts
-import { DocumentType, IncomeType } from "@withabound/node-sdk";
+import { IncomeDocumentType, IncomeType } from "@withabound/node-sdk";
 
 const userId = "userId_506...";
 
@@ -325,7 +325,7 @@ const response = await abound.incomes.create(userId, [
     amount: 10.85,
     date: "2020-12-15",
     description: "Savings Account interest accrued",
-    documentType: DocumentType.TEN99INT,
+    documentType: IncomeDocumentType.TEN99INT,
   },
 ]);
 

--- a/README.md
+++ b/README.md
@@ -310,7 +310,7 @@ console.log(response.data.status);
 Create `Income`s:
 
 ```ts
-import { IncomeType } from "@withabound/node-sdk";
+import { DocumentType, IncomeType } from "@withabound/node-sdk";
 
 const userId = "userId_506...";
 
@@ -319,6 +319,13 @@ const response = await abound.incomes.create(userId, [
     incomeType: IncomeType.W2,
     amount: 55000,
     date: "2020-12-30",
+  },
+  {
+    incomeType: IncomeType.TEN99,
+    amount: 10.85,
+    date: "2020-12-15",
+    description: "Savings Account interest accrued",
+    documentType: DocumentType.TEN99INT
   },
 ]);
 

--- a/README.md
+++ b/README.md
@@ -320,12 +320,6 @@ const response = await abound.incomes.create(userId, [
     amount: 55000,
     date: "2020-12-30",
   },
-  {
-    incomeType: IncomeType.TEN99INT,
-    amount: 10.85,
-    date: "2020-12-15",
-    description: "Savings Account interest accrued",
-  },
 ]);
 
 console.log(response.data); // list of created Incomes

--- a/README.md
+++ b/README.md
@@ -325,7 +325,7 @@ const response = await abound.incomes.create(userId, [
     amount: 10.85,
     date: "2020-12-15",
     description: "Savings Account interest accrued",
-    documentType: DocumentType.TEN99INT
+    documentType: DocumentType.TEN99INT,
   },
 ]);
 

--- a/src/resources/Documents.ts
+++ b/src/resources/Documents.ts
@@ -27,6 +27,11 @@ export interface Document {
 
 export enum DocumentType {
   ACCOUNT_STATEMENT = "accountStatement",
+  TEN99INT = "1099int",
+  TEN99K = "1099k",
+  TEN99MISC = "1099misc",
+  TEN99NEC = "1099nec",
+  W9 = "w9",
 }
 
 // The raw `Document` object returned from the APIs returns one deprecated field, which the SDK will remove.

--- a/src/resources/Documents.ts
+++ b/src/resources/Documents.ts
@@ -27,11 +27,6 @@ export interface Document {
 
 export enum DocumentType {
   ACCOUNT_STATEMENT = "accountStatement",
-  TEN99INT = "1099int",
-  TEN99K = "1099k",
-  TEN99MISC = "1099misc",
-  TEN99NEC = "1099nec",
-  W9 = "w9",
 }
 
 // The raw `Document` object returned from the APIs returns one deprecated field, which the SDK will remove.

--- a/src/resources/Incomes.ts
+++ b/src/resources/Incomes.ts
@@ -27,7 +27,6 @@ export interface Income extends IncomeRequest {
 
 export enum IncomeType {
   TEN99 = "1099",
-  TEN99INT = "1099-INT",
   W2 = "w2",
   PERSONAL = "personal",
 }

--- a/src/resources/Incomes.ts
+++ b/src/resources/Incomes.ts
@@ -1,6 +1,7 @@
 import { EmptyObject, Notes, Pagination } from "./base/AboundResource";
 import { AboundBulkResponse, AboundResponse } from "./base/AboundResponse";
 import { AboundUserScopedResource } from "./base/AboundUserScopedResource";
+import { DocumentType } from "./Documents";
 
 // request body
 export interface IncomeRequest {
@@ -11,6 +12,8 @@ export interface IncomeRequest {
   description?: string;
   category?: string;
   foreignId?: string;
+  // The specific document code used when filling out this income.
+  documentType?: DocumentType;
   notes?: Notes;
 }
 

--- a/src/resources/Incomes.ts
+++ b/src/resources/Incomes.ts
@@ -1,7 +1,6 @@
 import { EmptyObject, Notes, Pagination } from "./base/AboundResource";
 import { AboundBulkResponse, AboundResponse } from "./base/AboundResponse";
 import { AboundUserScopedResource } from "./base/AboundUserScopedResource";
-import { DocumentType } from "./Documents";
 
 // request body
 export interface IncomeRequest {
@@ -13,8 +12,16 @@ export interface IncomeRequest {
   category?: string;
   foreignId?: string;
   // The specific document code used when filling out this income.
-  documentType?: DocumentType;
+  documentType?: IncomeDocumentType;
   notes?: Notes;
+}
+
+export enum IncomeDocumentType {
+  TEN99INT = "1099int",
+  TEN99K = "1099k",
+  TEN99MISC = "1099misc",
+  TEN99NEC = "1099nec",
+  SSA1099 = "ssa1099",
 }
 
 // query params

--- a/tests/resources/Incomes.spec.ts
+++ b/tests/resources/Incomes.spec.ts
@@ -4,7 +4,11 @@ import {
   AboundBulkResponse,
   AboundResponse,
 } from "../../src/resources/base/AboundResponse";
-import { Income, IncomeDocumentType, IncomeType } from "../../src/resources/Incomes";
+import {
+  Income,
+  IncomeDocumentType,
+  IncomeType,
+} from "../../src/resources/Incomes";
 import { createAboundClient, randomString, TEST_USER_ID } from "../utils";
 
 const TEST_INCOME_ID = "incomeId_test8cb0d56b942722b6d719fa5aa9c5a8dbaa0f";

--- a/tests/resources/Incomes.spec.ts
+++ b/tests/resources/Incomes.spec.ts
@@ -4,8 +4,7 @@ import {
   AboundBulkResponse,
   AboundResponse,
 } from "../../src/resources/base/AboundResponse";
-import { DocumentType } from "../../src/resources/Documents";
-import { Income, IncomeType } from "../../src/resources/Incomes";
+import { Income, IncomeDocumentType, IncomeType } from "../../src/resources/Incomes";
 import { createAboundClient, randomString, TEST_USER_ID } from "../utils";
 
 const TEST_INCOME_ID = "incomeId_test8cb0d56b942722b6d719fa5aa9c5a8dbaa0f";
@@ -35,7 +34,7 @@ describe("Abound Incomes", () => {
             amount: 10.87,
             description,
             category,
-            documentType: DocumentType.TEN99INT,
+            documentType: IncomeDocumentType.TEN99INT,
           },
         ]);
 

--- a/tests/resources/Incomes.spec.ts
+++ b/tests/resources/Incomes.spec.ts
@@ -4,6 +4,7 @@ import {
   AboundBulkResponse,
   AboundResponse,
 } from "../../src/resources/base/AboundResponse";
+import { DocumentType } from "../../src/resources/Documents";
 import { Income, IncomeType } from "../../src/resources/Incomes";
 import { createAboundClient, randomString, TEST_USER_ID } from "../utils";
 
@@ -29,11 +30,12 @@ describe("Abound Incomes", () => {
             amount: 410.11,
           },
           {
-            incomeType: IncomeType.PERSONAL,
+            incomeType: IncomeType.TEN99,
             date: "2021-08-05",
             amount: 10.87,
             description,
             category,
+            documentType: DocumentType.TEN99INT,
           },
         ]);
 
@@ -90,7 +92,7 @@ describe("Abound Incomes", () => {
       const incomes: AboundBulkResponse<Income> = await abound.incomes.list(
         TEST_USER_ID,
         {
-          incomeType: IncomeType.PERSONAL,
+          incomeType: IncomeType.TEN99,
         }
       );
 

--- a/tests/resources/Incomes.spec.ts
+++ b/tests/resources/Incomes.spec.ts
@@ -29,7 +29,7 @@ describe("Abound Incomes", () => {
             amount: 410.11,
           },
           {
-            incomeType: IncomeType.TEN99INT,
+            incomeType: IncomeType.PERSONAL,
             date: "2021-08-05",
             amount: 10.87,
             description,
@@ -90,7 +90,7 @@ describe("Abound Incomes", () => {
       const incomes: AboundBulkResponse<Income> = await abound.incomes.list(
         TEST_USER_ID,
         {
-          incomeType: IncomeType.TEN99INT,
+          incomeType: IncomeType.PERSONAL,
         }
       );
 


### PR DESCRIPTION
This PR removes 1099-INT as a possible Income type, as it's no longer supported.

It also adds the `income.documentType` field.