### PR TITLE
FIX: export generic interfaces used to type raw response bodies

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@withabound/node-sdk",
-  "version": "1.2.0",
+  "version": "1.1.3",
   "description": "The Abound Node library provides convenient access to the Abound API from applications written in server-side JavaScript.",
   "author": "Abound <api@withabound.com>",
   "license": "MIT",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@withabound/node-sdk",
-  "version": "1.1.3",
+  "version": "1.2.0",
   "description": "The Abound Node library provides convenient access to the Abound API from applications written in server-side JavaScript.",
   "author": "Abound <api@withabound.com>",
   "license": "MIT",

--- a/src/abound.ts
+++ b/src/abound.ts
@@ -12,7 +12,7 @@ export * from "./resources/TaxCategories";
 export * from "./resources/Taxes";
 export * from "./resources/TaxPayments";
 export * from "./resources/Users";
-export * from './resources/base/AboundResponse';
+export * from "./resources/base/AboundResponse";
 
 // document-types
 export * from "./resources/document-types/1099INT";

--- a/src/abound.ts
+++ b/src/abound.ts
@@ -12,6 +12,7 @@ export * from "./resources/TaxCategories";
 export * from "./resources/Taxes";
 export * from "./resources/TaxPayments";
 export * from "./resources/Users";
+export * from './resources/base/AboundResponse';
 
 // document-types
 export * from "./resources/document-types/1099INT";

--- a/src/resources/base/AboundResponse.ts
+++ b/src/resources/base/AboundResponse.ts
@@ -12,7 +12,7 @@ export interface AboundBulkResponse<T> {
   request: RequestMetadata;
 }
 
-interface RequestMetadata {
+export interface RequestMetadata {
   timestamp: number;
   requestId: string;
 }


### PR DESCRIPTION
This PR allows for SDK consumers to use these generic types when invoking public methods. e.g.,

```ts
import { AboundBulkResponse, PaymentMethod } from "@withabound/node-sdk";

const response: AboundBulkResponse<PaymentMethod> = await abound.paymentMethods.list(aboundUserId);
```

Verified locally with `yalc`